### PR TITLE
Fix waiting for MetalLB controller

### DIFF
--- a/roles/kubernetes-apps/metallb/tasks/main.yml
+++ b/roles/kubernetes-apps/metallb/tasks/main.yml
@@ -33,7 +33,7 @@
     - inventory_hostname == groups['kube_control_plane'][0]
 
 - name: Kubernetes Apps | Wait for MetalLB controller to be running
-  command: "{{ bin_dir }}/kubectl -n metallb-system wait --for=condition=ready pod -l app=metallb,component=controller --timeout=2m"
+  command: "{{ bin_dir }}/kubectl rollout status -n metallb-system deployment -l app=metallb,component=controller --timeout=2m"
   become: true
   when:
     - inventory_hostname == groups['kube_control_plane'][0]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

I think the current state waiting method is bad to implement. When changing the deployment version, which is execute with the upgrade_cluster in the previous ansible task: "Kubernetes Apps | Install and configure MetalLB", next ansible task: "Kubernetes Apps | Wait for MetalLB controller to be running" may fall with an error.

```
[konstantin@kube ~]$ kubectl get deployments.apps -n metallb-system 
NAME         READY   UP-TO-DATE   AVAILABLE   AGE
controller   1/1     1            1           162d
[konstantin@kube ~]$ kubectl rollout restart deployment -n metallb-system controller ; kubectl -n metallb-system wait --for=condition=ready pod -l app=metallb,component=controller --timeout=2m ; echo $?
deployment.apps/controller restarted
pod/controller-849869d49d-5ftfp condition met
Error from server (NotFound): pods "controller-d48f5fc6f-l79nd" not found
1
```

Error not found pods controller-d48f5fc6f-l79nd is a result of changing deployment version аnd as a result, the execution of upgrade_cluster.yml failed.

I suggest changing the method of waiting for the current state to a more correct one in my opinion. 

```
[konstantin@kube ~]$ kubectl get deployments.apps -n metallb-system 
NAME         READY   UP-TO-DATE   AVAILABLE   AGE
controller   1/1     1            1           162d
[konstantin@kube ~]$ kubectl rollout restart deployment -n metallb-system controller ; kubectl rollout status -n metallb-system deployment -l app=metallb,component=controller --timeout=2m ; echo $?
deployment.apps/controller restarted
Waiting for deployment "controller" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "controller" rollout to finish: 1 old replicas are pending termination...
deployment "controller" successfully rolled out
0
```

In a situation when a deployment is created for the first time, this method also processes correctly.

```
[konstantin@kube ~]$ kubectl get deployments.apps -n metallb-system
No resources found in metallb-system namespace.
[konstantin@kube ~]$ kubectl apply -f controller.yml ; kubectl rollout status -n metallb-system deployment -l app=metallb,component=controller --timeout=2m ; echo $?
deployment.apps/controller created
Waiting for deployment "controller" rollout to finish: 0 of 1 updated replicas are available...
deployment "controller" successfully rolled out
0
[konstantin@kube ~]$ kubectl get deployments.apps -n metallb-system
NAME         READY   UP-TO-DATE   AVAILABLE   AGE
controller   1/1     1            1           15s
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
